### PR TITLE
Updated planning and execution parameters to wait for 'slow' Kinova

### DIFF
--- a/jackal_gen3_lite_moveit_config/launch/ompl_planning_pipeline.launch.xml
+++ b/jackal_gen3_lite_moveit_config/launch/ompl_planning_pipeline.launch.xml
@@ -18,7 +18,7 @@
   <param name="request_adapters" value="$(arg planning_adapters)" />
   <param name="start_state_max_bounds_error" value="$(arg start_state_max_bounds_error)" />
 
-  <param name="sample_duration" value="0.001"/>
+  <param name="sample_duration" value="0.1"/>
 
   <rosparam command="load" file="$(find jackal_gen3_lite_moveit_config)/config/ompl_planning.yaml"/>
 

--- a/jackal_gen3_lite_moveit_config/launch/trajectory_execution.launch.xml
+++ b/jackal_gen3_lite_moveit_config/launch/trajectory_execution.launch.xml
@@ -7,9 +7,9 @@
   <param name="moveit_manage_controllers" value="$(arg moveit_manage_controllers)"/>
 
   <!-- When determining the expected duration of a trajectory, this multiplicative factor is applied to get the allowed duration of execution -->
-  <param name="trajectory_execution/allowed_execution_duration_scaling" value="1.2"/> <!-- default 1.2 -->
+  <param name="trajectory_execution/allowed_execution_duration_scaling" value="2.0"/> <!-- default 1.2 -->
   <!-- Allow more than the expected execution time before triggering a trajectory cancel (applied after scaling) -->
-  <param name="trajectory_execution/allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
+  <param name="trajectory_execution/allowed_goal_duration_margin" value="2.0"/> <!-- default 0.5 -->
   <!-- Allowed joint-value tolerance for validation that trajectory's first point matches current robot state -->
   <param name="trajectory_execution/allowed_start_tolerance" value="0.01"/> <!-- default 0.01 -->
 


### PR DESCRIPTION
Same as: https://github.com/husky/husky_manipulation/commit/23b6cb82ecc6eb4720ca1bebcbc493e54e6ba0af

Required for MoveIt to generate a trajectory of size small enough (within 1000) for the ROS driver controller to accept and execute the trajectory.